### PR TITLE
chore(deps): consolidate safe dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       time: "04:00"
       timezone: Asia/Shanghai
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: /apps/admin
@@ -17,6 +21,21 @@ updates:
       time: "04:10"
       timezone: Asia/Shanghai
     open-pull-requests-limit: 5
+    groups:
+      react:
+        patterns:
+          - react
+          - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+      vite-toolchain:
+        patterns:
+          - vite
+          - "@vitejs/plugin-react"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: npm
     directory: /apps/webmail
@@ -26,3 +45,14 @@ updates:
       time: "04:20"
       timezone: Asia/Shanghai
     open-pull-requests-limit: 5
+    groups:
+      react:
+        patterns:
+          - react
+          - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+      vite-toolchain:
+        patterns:
+          - vite
+          - "@vitejs/plugin-react"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Initialize CodeQL
         uses: github/codeql-action/init@1ad29ea4a422cce9a242a9fae469541dcd08addc # v4
         with:

--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -51,12 +51,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -10,17 +10,17 @@
       "dependencies": {
         "@vitejs/plugin-react": "^5.0.4",
         "lucide-react": "^0.546.0",
-        "postal-mime": "^2.7.4",
-        "react": "^19.0.1",
-        "react-dom": "^19.0.1",
+        "postal-mime": "^2.7.6",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
         "vite": "^6.2.3",
         "vite-plugin-pwa": "^1.3.0"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.14",
         "@types/node": "^22.14.0",
-        "@types/react": "19.1.17",
-        "@types/react-dom": "19.1.7",
+        "@types/react": "19.2.18",
+        "@types/react-dom": "19.2.4",
         "playwright-core": "^1.61.1",
         "tailwindcss": "^4.1.14",
         "typescript": "~5.8.2"
@@ -2442,23 +2442,23 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.1.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
-      "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
-      "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -4565,9 +4565,9 @@
       }
     },
     "node_modules/postal-mime": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
-      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.6.tgz",
+      "integrity": "sha512-UUlyE2KlxmvwMGq060onF/VWU3zD6dVW31FwokQ5v26jWd35fbs2MoTFzh+jXnPwAyV2MULMKXcBInGOl5TO6Q==",
       "license": "MIT-0"
     },
     "node_modules/postcss": {
@@ -4620,24 +4620,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-refresh": {

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -16,17 +16,17 @@
   "dependencies": {
     "@vitejs/plugin-react": "^5.0.4",
     "lucide-react": "^0.546.0",
-    "postal-mime": "^2.7.4",
-    "react": "^19.0.1",
-    "react-dom": "^19.0.1",
+    "postal-mime": "^2.7.6",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "vite": "^6.2.3",
     "vite-plugin-pwa": "^1.3.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.14",
     "@types/node": "^22.14.0",
-    "@types/react": "19.1.17",
-    "@types/react-dom": "19.1.7",
+    "@types/react": "19.2.18",
+    "@types/react-dom": "19.2.4",
     "playwright-core": "^1.61.1",
     "tailwindcss": "^4.1.14",
     "typescript": "~5.8.2"

--- a/apps/webmail/package-lock.json
+++ b/apps/webmail/package-lock.json
@@ -9,15 +9,15 @@
       "version": "0.5.1",
       "dependencies": {
         "@vitejs/plugin-react": "^5.0.4",
-        "postal-mime": "^2.7.4",
-        "react": "19.1.0",
-        "react-dom": "19.1.0",
+        "postal-mime": "^2.7.6",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
         "typescript": "~5.9.3",
         "vite": "^6.4.2"
       },
       "devDependencies": {
-        "@types/react": "19.1.17",
-        "@types/react-dom": "19.1.7"
+        "@types/react": "19.2.18",
+        "@types/react-dom": "19.2.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1123,23 +1123,23 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
-      "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
-      "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1444,9 +1444,9 @@
       }
     },
     "node_modules/postal-mime": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
-      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.6.tgz",
+      "integrity": "sha512-UUlyE2KlxmvwMGq060onF/VWU3zD6dVW31FwokQ5v26jWd35fbs2MoTFzh+jXnPwAyV2MULMKXcBInGOl5TO6Q==",
       "license": "MIT-0"
     },
     "node_modules/postcss": {
@@ -1478,24 +1478,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.1.0"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-refresh": {
@@ -1552,9 +1552,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {

--- a/apps/webmail/package.json
+++ b/apps/webmail/package.json
@@ -21,12 +21,12 @@
     "@vitejs/plugin-react": "^5.0.4",
     "vite": "^6.4.2",
     "typescript": "~5.9.3",
-    "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "postal-mime": "^2.7.4"
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "postal-mime": "^2.7.6"
   },
   "devDependencies": {
-    "@types/react": "19.1.17",
-    "@types/react-dom": "19.1.7"
+    "@types/react": "19.2.18",
+    "@types/react-dom": "19.2.4"
   }
 }


### PR DESCRIPTION
## Summary
- update React, React DOM, their type declarations, and postal-mime as coordinated app-level sets
- update checkout/setup-node actions to v7 while keeping CodeQL checkout SHA-pinned
- group related Dependabot updates and suppress @types/node majors beyond the Node 22 runtime

## Validation
- npm ci in apps/admin and apps/webmail
- npm run check:release
- dependency audit: 0 vulnerabilities in both apps

Supersedes #3, #4, #8, #9, #13, #14, #21, and #22.