### PR TITLE
feat(admin): safely reveal remote mail images

### DIFF
--- a/apps/admin/scripts/smoke-local.mjs
+++ b/apps/admin/scripts/smoke-local.mjs
@@ -1060,8 +1060,14 @@ async function main() {
     assert(mailFrameText.includes('Your verification code is 123456'), `mail detail iframe should render decoded multipart body: ${mailFrameText || mobileMailDetail.bodySample}`);
     assert(!/Content-Transfer-Encoding|--smoke-boundary|Content-Type: multipart/i.test(mobileMailDetail.bodySample), `mail detail should not show raw MIME source: ${mobileMailDetail.bodySample}`);
     assert(!/Content-Transfer-Encoding|--smoke-boundary|Content-Type: multipart/i.test(mailFrameText), `mail detail iframe should not show raw MIME source: ${mailFrameText}`);
-    const mailFrameSrcdoc = await evaluate(mobile, `document.querySelector('.mail-frame')?.getAttribute('srcdoc') || ''`);
-    assert(mailFrameSrcdoc.includes('/api/image?url='), `admin remote mail image should use the same-origin proxy: ${mailFrameSrcdoc}`);
+    const blockedMailFrameSrcdoc = await evaluate(mobile, `document.querySelector('.mail-frame')?.getAttribute('srcdoc') || ''`);
+    assert(blockedMailFrameSrcdoc.includes('data-blocked-src='), `admin remote mail image should be blocked before consent: ${blockedMailFrameSrcdoc}`);
+    assert(!blockedMailFrameSrcdoc.includes('/api/image?url='), `admin must not request a remote image proxy before consent: ${blockedMailFrameSrcdoc}`);
+    assert(await evaluate(mobile, `document.body.innerText.includes('显示远程图片')`), 'remote image consent button should be visible for image-bearing mail');
+    await clickText(mobile, '显示远程图片');
+    await waitUntil(mobile, `document.querySelector('.mail-frame')?.getAttribute('srcdoc')?.includes('/api/image?url=')`);
+    const allowedMailFrameSrcdoc = await evaluate(mobile, `document.querySelector('.mail-frame')?.getAttribute('srcdoc') || ''`);
+    assert(allowedMailFrameSrcdoc.includes('/api/image?url='), `consented admin remote mail image should use the same-origin proxy: ${allowedMailFrameSrcdoc}`);
     const mailFrameRect = JSON.parse(await evaluate(mobile, `JSON.stringify((() => {
       const rect = document.querySelector('.mail-frame')?.getBoundingClientRect();
       return rect ? { left: rect.left, right: rect.right, top: rect.top, bottom: rect.bottom, width: rect.width, height: rect.height } : null;

--- a/apps/admin/src/lib/mailParser.ts
+++ b/apps/admin/src/lib/mailParser.ts
@@ -55,6 +55,31 @@ function collectVerificationCodes(subject: string, text: string, html = ''): str
   return extractVerificationCodes(`${subject}\n${text}`, [html]);
 }
 
+const EXTERNAL_IMAGE_URL = /^\s*(?:https?:)?\/\//i;
+const EXTERNAL_CSS_IMAGE = /url\(\s*['"]?(?:https?:)?\/\//i;
+
+export function hasExternalMailImages(html: string): boolean {
+  if (!html) return false;
+  if (typeof window !== 'undefined' && window.DOMParser) {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    for (const element of doc.querySelectorAll('img, [background], video[poster], input[type="image"]')) {
+      for (const name of ['src', 'srcset', 'background', 'poster']) {
+        const value = element.getAttribute(name);
+        if (value && value.split(',').some((candidate) => EXTERNAL_IMAGE_URL.test(candidate.trim()))) return true;
+      }
+    }
+    for (const element of doc.querySelectorAll<HTMLElement>('[style], style')) {
+      const css = element.getAttribute('style') || element.textContent || '';
+      if (EXTERNAL_CSS_IMAGE.test(css)) return true;
+    }
+    return false;
+  }
+
+  return /<(?:img|video|input)\b[^>]*\b(?:src|srcset|poster)\s*=\s*['"][^'"]*(?:https?:)?\/\//i.test(html)
+    || /<[^>]*\bbackground\s*=\s*['"][^'"]*(?:https?:)?\/\//i.test(html)
+    || /(?:\bstyle\s*=\s*['"][^'"]*|<style\b[^>]*>[\s\S]*?)url\(\s*['"]?(?:https?:)?\/\//i.test(html);
+}
+
 export function sanitizeMailHtml(html: string, options: { allowExternalImages?: boolean } = {}): string {
   if (!html) return '';
   if (typeof window === 'undefined' || !window.DOMParser) {

--- a/apps/admin/src/views/MailWorkspace.tsx
+++ b/apps/admin/src/views/MailWorkspace.tsx
@@ -1,5 +1,5 @@
 import { memo, startTransition, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, type CSSProperties, type MouseEvent, type PointerEvent, type TouchEvent, type UIEvent } from 'react';
-import { Archive, CheckCheck, ChevronDown, ChevronLeft, ChevronRight, Download, MoreHorizontal, Paperclip, RefreshCw, Reply, Star, Trash2, X } from 'lucide-react';
+import { Archive, CheckCheck, ChevronDown, ChevronLeft, ChevronRight, Download, Image, MoreHorizontal, Paperclip, RefreshCw, Reply, Star, Trash2, X } from 'lucide-react';
 import { type Requester } from '../lib/api';
 import { ADDRESS_INPUT_DEBOUNCE_MS, COPY_HINT_MS, DEFAULT_PAGE_SIZE, NEW_MAIL_FLASH_MS, STORAGE_KEYS } from '../lib/constants';
 import { cls, formatShortDate, normalizeSearch } from '../lib/format';
@@ -8,7 +8,7 @@ import { copyText } from '../lib/clipboard';
 import { readStorage, writeLocalStorage } from '../lib/storage';
 import { preserveRowsBelowAuthoritativeHead } from '../lib/mailSync';
 import { readTrustedMailFrameMessage } from '../lib/mailFrameMessages';
-import { buildMailHtmlDocument, getDownloadEmlUrl, looksLikeMimeSource, parseRawMail, sanitizeMailHtml, sanitizeVerificationCode } from '../lib/mailParser';
+import { buildMailHtmlDocument, getDownloadEmlUrl, hasExternalMailImages, looksLikeMimeSource, parseRawMail, sanitizeVerificationCode } from '../lib/mailParser';
 import type { ComposePayload, ParsedMail, ParsedSendbox } from '../types/api';
 import { EmptyState, LoadingState, type Notify, useConfirm } from '../components/Common';
 import { BrandAvatar } from '../lib/brandIdentity';
@@ -1623,14 +1623,14 @@ export function MailWorkspace({ mode, active, visualActive = active, request, no
         </div>
       </div>
       <div className="mail-detail-pane hidden h-full min-w-0 flex-1 flex-col lg:flex">
-        {!compactViewport && <MailDetail cacheScope={mailStateScope} mail={selected} mode={mode} locale={locale} theme={theme} copiedKey={copiedKey} deletingMailId={deletingMailId} onDelete={deleteMail} onReply={(mail) => composeFromMail(mail, 'reply')} onForward={(mail) => composeFromMail(mail, 'forward')} onCopy={copyValue} onToggleStar={toggleStar} onClose={() => setDetailClosed(true)} onPrevious={() => navigateDetail(-1)} onNext={() => navigateDetail(1)} canPrevious={selectedIndex > 0} canNext={selectedIndex >= 0 && selectedIndex < filtered.length - 1} positionLabel={detailPositionLabel} onFrameWindowChange={(frameWindow) => { activeMailFrameWindowRef.current = frameWindow; }} />}
+        {!compactViewport && <MailDetail key={`${mode}-${selected?.id ?? 'empty'}`} cacheScope={mailStateScope} mail={selected} mode={mode} locale={locale} theme={theme} copiedKey={copiedKey} deletingMailId={deletingMailId} onDelete={deleteMail} onReply={(mail) => composeFromMail(mail, 'reply')} onForward={(mail) => composeFromMail(mail, 'forward')} onCopy={copyValue} onToggleStar={toggleStar} onClose={() => setDetailClosed(true)} onPrevious={() => navigateDetail(-1)} onNext={() => navigateDetail(1)} canPrevious={selectedIndex > 0} canNext={selectedIndex >= 0 && selectedIndex < filtered.length - 1} positionLabel={detailPositionLabel} onFrameWindowChange={(frameWindow) => { activeMailFrameWindowRef.current = frameWindow; }} />}
       </div>
       {isMobileDetail && (
         <div
           className={cls('mobile-mail-detail absolute inset-0 z-40 flex h-full min-h-0 flex-col bg-white lg:hidden', mobileDetailSettling && 'mobile-detail-settling')}
           style={{ transform: `translate3d(${mobileDetailDragX}px, 0, 0)` }}
         >
-          <MailDetail cacheScope={mailStateScope} mail={selected} mode={mode} locale={locale} theme={theme} copiedKey={copiedKey} deletingMailId={deletingMailId} onDelete={deleteMail} onReply={(mail) => composeFromMail(mail, 'reply')} onForward={(mail) => composeFromMail(mail, 'forward')} onCopy={copyValue} onToggleStar={toggleStar} onClose={() => { setDetailClosed(true); setIsMobileDetail(false); setMobileDetailDragX(0); }} onPrevious={() => navigateDetail(-1)} onNext={() => navigateDetail(1)} canPrevious={selectedIndex > 0} canNext={selectedIndex >= 0 && selectedIndex < filtered.length - 1} positionLabel={detailPositionLabel} onFrameWindowChange={(frameWindow) => { activeMailFrameWindowRef.current = frameWindow; }} mobile />
+          <MailDetail key={`${mode}-${selected?.id ?? 'empty'}`} cacheScope={mailStateScope} mail={selected} mode={mode} locale={locale} theme={theme} copiedKey={copiedKey} deletingMailId={deletingMailId} onDelete={deleteMail} onReply={(mail) => composeFromMail(mail, 'reply')} onForward={(mail) => composeFromMail(mail, 'forward')} onCopy={copyValue} onToggleStar={toggleStar} onClose={() => { setDetailClosed(true); setIsMobileDetail(false); setMobileDetailDragX(0); }} onPrevious={() => navigateDetail(-1)} onNext={() => navigateDetail(1)} canPrevious={selectedIndex > 0} canNext={selectedIndex >= 0 && selectedIndex < filtered.length - 1} positionLabel={detailPositionLabel} onFrameWindowChange={(frameWindow) => { activeMailFrameWindowRef.current = frameWindow; }} mobile />
         </div>
       )}
     </div>
@@ -1937,9 +1937,11 @@ function MailDetail({
   const parsedForMemo = mail ? isParsed(mail) : false;
   const htmlForFrame = mail ? String(parsedForMemo ? mail.message : mail.is_html ? mail.content : '') : '';
   const rawForDownload = mail && parsedForMemo ? String(mail.raw || '') : '';
+  const [allowExternalImages, setAllowExternalImages] = useState(false);
+  const hasExternalImages = useMemo(() => hasExternalMailImages(htmlForFrame), [htmlForFrame]);
   const iframeDocument = useMemo(() => {
-    return htmlForFrame ? buildMailHtmlDocument(parsedForMemo ? htmlForFrame : sanitizeMailHtml(htmlForFrame)) : '';
-  }, [htmlForFrame, parsedForMemo]);
+    return htmlForFrame ? buildMailHtmlDocument(htmlForFrame, 'light', { allowExternalImages }) : '';
+  }, [allowExternalImages, htmlForFrame]);
   const emlUrl = useMemo(() => (rawForDownload ? getDownloadEmlUrl(rawForDownload) : ''), [rawForDownload]);
   useEffect(() => () => { if (emlUrl) URL.revokeObjectURL(emlUrl); }, [emlUrl]);
   if (!mail) return <div className="p-8"><EmptyState title={t('请选择一封邮件', 'Select a message')} /></div>;
@@ -2002,6 +2004,12 @@ function MailDetail({
             </div>
           </header>
           <div className="my-2 h-px shrink-0 bg-slate-100 md:my-2.5" />
+          {hasExternalImages && !allowExternalImages ? (
+            <div className="mb-2 flex shrink-0 flex-wrap items-center justify-between gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+              <span>{t('远程图片已阻止，以保护隐私。', 'Remote images are blocked to protect your privacy.')}</span>
+              <button type="button" className="btn-secondary compact shrink-0" onClick={() => setAllowExternalImages(true)}><Image size={15} /> {t('显示远程图片', 'Show remote images')}</button>
+            </div>
+          ) : null}
           {verificationCodes.length > 0 && (
             <div className="mail-detail-code-strip mb-2 flex shrink-0 flex-wrap items-center gap-2" aria-label={t('验证码快捷复制', 'Quick-copy verification codes')}>
               <span className="text-xs font-semibold text-slate-500">{t('验证码', 'Verification code')}</span>

--- a/apps/admin/tests/frontend-release.test.ts
+++ b/apps/admin/tests/frontend-release.test.ts
@@ -11,7 +11,7 @@ import { buildCacheScope, scopedStorageKey } from '../src/lib/cacheScope.ts';
 import { buildAddressLoginUrl } from '../src/lib/clipboard.ts';
 import { UserApiError, addressMailEndpoint, changeAddressPassword, createUserShare, fetchUserProfile, isAuthenticationFailure, loginAccountUser, registerAccountUser } from '../src/lib/userAuth.ts';
 import { readTrustedMailFrameMessage } from '../src/lib/mailFrameMessages.ts';
-import { parseRawMailListItem } from '../src/lib/mailParser.ts';
+import { hasExternalMailImages, parseRawMailListItem } from '../src/lib/mailParser.ts';
 import { adminMailStateEndpoint } from '../src/lib/mailStateEndpoint.ts';
 import { proxyMailImageSrcset, proxyMailImageUrl } from '../src/lib/mailImageProxy.ts';
 import { sanitizeMailHtmlWithoutDom } from '../src/lib/mailSanitizerFallback.ts';
@@ -190,6 +190,20 @@ test('admin routes remote mail images through its same-origin proxy', () => {
     ),
     'data:image/png;base64,AA== 1x, https://admin.example.test/api/image?url=https%3A%2F%2Fassets.example.com%2Fnotion-logo.png 2x',
   );
+});
+
+test('admin remote image consent is limited to image-bearing HTML and the active message', () => {
+  assert.equal(hasExternalMailImages('<img src="https://assets.example.test/pixel.png">'), true);
+  assert.equal(hasExternalMailImages('<img srcset="https://assets.example.test/a.png 1x, data:image/png;base64,AA== 2x">'), true);
+  assert.equal(hasExternalMailImages('<div style="background-image:url(//assets.example.test/banner.png)">Hello</div>'), true);
+  assert.equal(hasExternalMailImages('<a href="https://example.test">Link only</a><img src="data:image/png;base64,AA==">'), false);
+
+  const workspaceSource = readFileSync(new URL('../src/views/MailWorkspace.tsx', import.meta.url), 'utf8');
+  assert.equal((workspaceSource.match(/<MailDetail key=/g) || []).length, 2, 'desktop and mobile details must remount for each mail identity');
+  assert.match(workspaceSource, /key=\{`\$\{mode\}-\$\{selected\?\.id \?\? 'empty'\}`\}/, 'mail mode and id must scope remote-image permission');
+  assert.match(workspaceSource, /useState\(false\)/, 'external images must be blocked on every fresh mail detail');
+  assert.match(workspaceSource, /allowExternalImages \}\)/, 'the iframe document must receive the explicit permission');
+  assert.doesNotMatch(workspaceSource, /setAllowExternalImages\(false\)[\s\S]{0,80}\[mail\?\.id\]/, 'an after-paint effect can leak a new mail image before resetting permission');
 });
 
 test('verification extraction keeps the exact Notion code and removes a spaced numeric suffix', () => {


### PR DESCRIPTION
## Summary
- block external images in Admin mail details by default
- show the consent control only when the active message actually contains external images
- load approved images through the existing same-origin image proxy
- reset approval when switching mailbox mode or message identity
- preserve the original contributor attribution from #15

## Security behavior
- before consent, remote URLs are stored only in `data-blocked-*` attributes
- before consent, the iframe document contains no `/api/image?url=` request
- after consent, supported remote images are rewritten through the same-origin proxy

## Validation
- `npm run check:release`
- Admin: 86 tests passed
- Webmail: 31 tests passed
- installer: 81 tests passed
- Admin/Webmail production builds passed
- Admin/Webmail browser smoke tests returned `ok: true`
- `git diff --check`

Supersedes #15 with additional privacy and regression coverage.