### PR TITLE
chore(deps): migrate Admin and Webmail to TypeScript 7

### DIFF
--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -23,7 +23,7 @@
         "@types/react-dom": "19.2.4",
         "playwright-core": "^1.61.1",
         "tailwindcss": "^4.1.14",
-        "typescript": "~5.8.2"
+        "typescript": "~7.0.2"
       }
     },
     "node_modules/@apideck/better-ajv-errors": {
@@ -2472,6 +2472,346 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
@@ -5404,17 +5744,38 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/unbox-primitive": {

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -29,7 +29,7 @@
     "@types/react-dom": "19.2.4",
     "playwright-core": "^1.61.1",
     "tailwindcss": "^4.1.14",
-    "typescript": "~5.8.2"
+    "typescript": "~7.0.2"
   },
   "overrides": {
     "filelist": "2.0.2"

--- a/apps/webmail/package-lock.json
+++ b/apps/webmail/package-lock.json
@@ -12,7 +12,7 @@
         "postal-mime": "^2.7.6",
         "react": "19.2.8",
         "react-dom": "19.2.8",
-        "typescript": "~5.9.3",
+        "typescript": "~7.0.2",
         "vite": "^6.4.2"
       },
       "devDependencies": {
@@ -1142,6 +1142,326 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
@@ -1592,16 +1912,37 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/apps/webmail/package.json
+++ b/apps/webmail/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@vitejs/plugin-react": "^5.0.4",
     "vite": "^6.4.2",
-    "typescript": "~5.9.3",
+    "typescript": "~7.0.2",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "postal-mime": "^2.7.6"

--- a/apps/webmail/scripts/check-brand-icon-proxy.mjs
+++ b/apps/webmail/scripts/check-brand-icon-proxy.mjs
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import ts from 'typescript';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { compileTypeScriptFiles } from './typescript-compile.mjs';
 
 const PNG_BYTES = Uint8Array.from([
   0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
@@ -12,17 +13,11 @@ const PNG_BYTES = Uint8Array.from([
 
 async function importRoute(sourceUrl, label) {
   const tempRoot = await mkdtemp(path.join(tmpdir(), `loven7-brand-${label}-`));
-  const source = await readFile(sourceUrl, 'utf8');
-  const output = ts.transpileModule(source, {
-    fileName: sourceUrl.pathname,
-    reportDiagnostics: true,
-    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
-  });
-  const diagnostics = output.diagnostics?.filter((item) => item.category === ts.DiagnosticCategory.Error) || [];
-  if (diagnostics.length) throw new Error(diagnostics.map((item) => ts.flattenDiagnosticMessageText(item.messageText, '\n')).join('\n'));
-  const routePath = path.join(tempRoot, 'brand-icon.mjs');
-  await writeFile(routePath, output.outputText, 'utf8');
-  return { tempRoot, route: await import(new URL(`file:///${routePath.replace(/\\/g, '/')}`).href) };
+  const sourcePath = fileURLToPath(sourceUrl);
+  const sourceRoot = fileURLToPath(new URL(label === 'webmail' ? '../functions/' : '../../admin/functions/', import.meta.url));
+  await compileTypeScriptFiles({ sourceRoot, rootFiles: [sourcePath], outDir: tempRoot });
+  const routePath = path.join(tempRoot, 'api', 'brand-icon.js');
+  return { tempRoot, route: await import(pathToFileURL(routePath).href) };
 }
 
 class MemoryCache {

--- a/apps/webmail/scripts/check-functions-headers.mjs
+++ b/apps/webmail/scripts/check-functions-headers.mjs
@@ -1,32 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
-import ts from 'typescript';
-
-async function importTsModule(relativePath) {
-  const sourceUrl = new URL(relativePath, import.meta.url);
-  const source = await readFile(sourceUrl, 'utf8');
-  const transpiled = ts.transpileModule(source, {
-    fileName: sourceUrl.pathname,
-    reportDiagnostics: true,
-    compilerOptions: {
-      module: ts.ModuleKind.ESNext,
-      target: ts.ScriptTarget.ES2022,
-    },
-  });
-
-  const diagnostics = transpiled.diagnostics?.filter((item) => item.category === ts.DiagnosticCategory.Error) || [];
-  if (diagnostics.length) {
-    const messages = diagnostics.map((item) => ts.flattenDiagnosticMessageText(item.messageText, '\n')).join('\n');
-    throw new Error(`${relativePath}\n${messages}`);
-  }
-
-  const moduleUrl = `data:text/javascript;base64,${Buffer.from(transpiled.outputText, 'utf8').toString('base64')}`;
-  return import(moduleUrl);
-}
+import { importStandaloneTypeScriptModule } from './typescript-compile.mjs';
 
 const { errorJson, json, mapUpstreamError, RuntimeConfigError, runtimeConfigErrorJson, UpstreamError, withCors } =
-  await importTsModule('../functions/_lib/http.ts');
-const { runtimeDiagnostics } = await importTsModule('../functions/_lib/runtime.ts');
+  await importStandaloneTypeScriptModule(new URL('../functions/_lib/http.ts', import.meta.url));
+const { runtimeDiagnostics } = await importStandaloneTypeScriptModule(new URL('../functions/_lib/runtime.ts', import.meta.url));
 
 function assertNoStore(response, label) {
   assert.equal(response.headers.get('cache-control'), 'no-store, private, max-age=0', `${label}: Cache-Control`);

--- a/apps/webmail/scripts/check-image-proxy.mjs
+++ b/apps/webmail/scripts/check-image-proxy.mjs
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import ts from 'typescript';
+import { fileURLToPath } from 'node:url';
+import { compileTypeScriptFiles } from './typescript-compile.mjs';
 
 const PNG_BYTES = Uint8Array.from([
   0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
@@ -15,58 +16,18 @@ const MAX_IMAGE_BYTES = 2 * 1024 * 1024;
 
 async function transpileToTemp() {
   const tempRoot = await mkdtemp(path.join(tmpdir(), 'loven7-image-proxy-check-'));
-  const libDir = path.join(tempRoot, '_lib');
-  const apiDir = path.join(tempRoot, 'api');
-  await mkdir(libDir, { recursive: true });
-  await mkdir(apiDir, { recursive: true });
-
-  const files = [
-    {
-      from: new URL('../functions/_lib/http.ts', import.meta.url),
-      to: path.join(libDir, 'http.mjs'),
-      patch: (code) => code,
-    },
-    {
-      from: new URL('../functions/api/image.ts', import.meta.url),
-      to: path.join(apiDir, 'image.mjs'),
-      patch: (code) => code.replace(/from\s+["']\.\.\/_lib\/http["'];/g, 'from "../_lib/http.mjs";'),
-    },
-  ];
-
-  for (const file of files) {
-    const source = await readFile(file.from, 'utf8');
-    const output = ts.transpileModule(source, {
-      fileName: file.from.pathname,
-      reportDiagnostics: true,
-      compilerOptions: {
-        module: ts.ModuleKind.ESNext,
-        target: ts.ScriptTarget.ES2022,
-      },
-    });
-    const diagnostics = output.diagnostics?.filter((item) => item.category === ts.DiagnosticCategory.Error) || [];
-    if (diagnostics.length) {
-      const messages = diagnostics.map((item) => ts.flattenDiagnosticMessageText(item.messageText, '\n')).join('\n');
-      throw new Error(messages);
-    }
-    await writeFile(file.to, file.patch(output.outputText), 'utf8');
-  }
-
-  return { tempRoot, imageModulePath: path.join(apiDir, 'image.mjs') };
+  const sourceRoot = fileURLToPath(new URL('../functions/', import.meta.url));
+  const imageSource = path.join(sourceRoot, 'api', 'image.ts');
+  await compileTypeScriptFiles({ sourceRoot, rootFiles: [imageSource], outDir: tempRoot });
+  return { tempRoot, imageModulePath: path.join(tempRoot, 'api', 'image.js') };
 }
 
 async function transpileAdminRouteToTemp() {
   const tempRoot = await mkdtemp(path.join(tmpdir(), 'loven7-admin-image-proxy-check-'));
-  const sourceUrl = new URL('../../admin/functions/api/image.ts', import.meta.url);
-  const source = await readFile(sourceUrl, 'utf8');
-  const output = ts.transpileModule(source, {
-    fileName: sourceUrl.pathname,
-    reportDiagnostics: true,
-    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
-  });
-  const diagnostics = output.diagnostics?.filter((item) => item.category === ts.DiagnosticCategory.Error) || [];
-  if (diagnostics.length) throw new Error(diagnostics.map((item) => ts.flattenDiagnosticMessageText(item.messageText, '\n')).join('\n'));
-  const imageModulePath = path.join(tempRoot, 'image.mjs');
-  await writeFile(imageModulePath, output.outputText, 'utf8');
+  const sourcePath = fileURLToPath(new URL('../../admin/functions/api/image.ts', import.meta.url));
+  const sourceRoot = path.dirname(sourcePath);
+  await compileTypeScriptFiles({ sourceRoot, rootFiles: [sourcePath], outDir: tempRoot });
+  const imageModulePath = path.join(tempRoot, 'image.js');
   return { tempRoot, imageModulePath };
 }
 

--- a/apps/webmail/scripts/check-pages-function-regressions.mjs
+++ b/apps/webmail/scripts/check-pages-function-regressions.mjs
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import ts from 'typescript';
+import { compileTypeScriptFiles } from './typescript-compile.mjs';
 
 async function walk(root) {
   const result = [];
@@ -16,29 +16,7 @@ async function walk(root) {
 
 async function compileTree(sourceRoot, label) {
   const tempRoot = await mkdtemp(path.join(tmpdir(), `loven7-${label}-`));
-  for (const sourcePath of await walk(sourceRoot)) {
-    const relative = path.relative(sourceRoot, sourcePath);
-    const outputPath = path.join(tempRoot, relative.replace(/\.ts$/, '.mjs'));
-    await mkdir(path.dirname(outputPath), { recursive: true });
-    const source = await readFile(sourcePath, 'utf8');
-    const output = ts.transpileModule(source, {
-      fileName: sourcePath,
-      reportDiagnostics: true,
-      compilerOptions: {
-        module: ts.ModuleKind.ESNext,
-        target: ts.ScriptTarget.ES2022,
-      },
-    });
-    const diagnostics = output.diagnostics?.filter((item) => item.category === ts.DiagnosticCategory.Error) || [];
-    if (diagnostics.length) {
-      throw new Error(diagnostics.map((item) => ts.flattenDiagnosticMessageText(item.messageText, '\n')).join('\n'));
-    }
-    const patched = output.outputText.replace(
-      /(from\s+["'])(\.{1,2}\/[^"']+?)(["'])/g,
-      (match, before, specifier, after) => `${before}${/\.[a-z]+$/i.test(specifier) ? specifier : `${specifier}.mjs`}${after}`,
-    );
-    await writeFile(outputPath, patched, 'utf8');
-  }
+  await compileTypeScriptFiles({ sourceRoot, rootFiles: await walk(sourceRoot), outDir: tempRoot });
   return tempRoot;
 }
 
@@ -125,18 +103,18 @@ try {
   webmailTemp = await compileTree(webmailFunctions, 'webmail-functions-check');
   adminTemp = await compileTree(adminFunctions, 'admin-functions-check');
 
-  const mailState = await import(moduleUrl(webmailTemp, 'api/mail-state.mjs'));
-  const shareLib = await import(moduleUrl(webmailTemp, '_lib/share.mjs'));
-  const shareUserLib = await import(moduleUrl(webmailTemp, '_lib/shareUser.mjs'));
-  const sharePatch = await import(moduleUrl(webmailTemp, 'api/share/admin/[token].mjs'));
-  const shareDelete = await import(moduleUrl(webmailTemp, 'api/share/[token]/mail/[id].mjs'));
-  const shareMails = await import(moduleUrl(webmailTemp, 'api/share/[token]/mails.mjs'));
-  const shareCreate = await import(moduleUrl(webmailTemp, 'api/share/index.mjs'));
-  const sessionRoute = await import(moduleUrl(webmailTemp, 'api/session.mjs'));
-  const registerRoute = await import(moduleUrl(webmailTemp, 'api/user/register.mjs'));
-  const loginRoute = await import(moduleUrl(webmailTemp, 'api/user/login.mjs'));
-  const adminProxy = await import(moduleUrl(adminTemp, '_lib/admin-proxy.mjs'));
-  const adminMailState = await import(moduleUrl(adminTemp, 'api/mail-state.mjs'));
+  const mailState = await import(moduleUrl(webmailTemp, 'api/mail-state.js'));
+  const shareLib = await import(moduleUrl(webmailTemp, '_lib/share.js'));
+  const shareUserLib = await import(moduleUrl(webmailTemp, '_lib/shareUser.js'));
+  const sharePatch = await import(moduleUrl(webmailTemp, 'api/share/admin/[token].js'));
+  const shareDelete = await import(moduleUrl(webmailTemp, 'api/share/[token]/mail/[id].js'));
+  const shareMails = await import(moduleUrl(webmailTemp, 'api/share/[token]/mails.js'));
+  const shareCreate = await import(moduleUrl(webmailTemp, 'api/share/index.js'));
+  const sessionRoute = await import(moduleUrl(webmailTemp, 'api/session.js'));
+  const registerRoute = await import(moduleUrl(webmailTemp, 'api/user/register.js'));
+  const loginRoute = await import(moduleUrl(webmailTemp, 'api/user/login.js'));
+  const adminProxy = await import(moduleUrl(adminTemp, '_lib/admin-proxy.js'));
+  const adminMailState = await import(moduleUrl(adminTemp, 'api/mail-state.js'));
 
   // A forged JWT must never be accepted as an identity when the Worker rejects it.
   {

--- a/apps/webmail/scripts/check-share-cors.mjs
+++ b/apps/webmail/scripts/check-share-cors.mjs
@@ -1,35 +1,16 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import ts from 'typescript';
+import { fileURLToPath } from 'node:url';
+import { compileTypeScriptFiles } from './typescript-compile.mjs';
 
 async function transpileHttpToTemp() {
   const tempRoot = await mkdtemp(path.join(tmpdir(), 'loven7-share-cors-check-'));
-  const libDir = path.join(tempRoot, '_lib');
-  await mkdir(libDir, { recursive: true });
-
-  for (const name of ['types', 'http']) {
-    const sourceUrl = new URL(`../functions/_lib/${name}.ts`, import.meta.url);
-    const source = await readFile(sourceUrl, 'utf8');
-    const output = ts.transpileModule(source, {
-      fileName: sourceUrl.pathname,
-      reportDiagnostics: true,
-      compilerOptions: {
-        module: ts.ModuleKind.ESNext,
-        target: ts.ScriptTarget.ES2022,
-      },
-    });
-    const diagnostics = output.diagnostics?.filter((item) => item.category === ts.DiagnosticCategory.Error) || [];
-    if (diagnostics.length) {
-      const messages = diagnostics.map((item) => ts.flattenDiagnosticMessageText(item.messageText, '\n')).join('\n');
-      throw new Error(messages);
-    }
-    const patched = output.outputText.replace(/from\s+["']\.\/types["'];/g, 'from "./types.mjs";');
-    await writeFile(path.join(libDir, `${name}.mjs`), patched, 'utf8');
-  }
-
-  return { tempRoot, httpModulePath: path.join(libDir, 'http.mjs') };
+  const sourceRoot = fileURLToPath(new URL('../functions/', import.meta.url));
+  const rootFiles = ['types.ts', 'http.ts'].map((name) => path.join(sourceRoot, '_lib', name));
+  await compileTypeScriptFiles({ sourceRoot, rootFiles, outDir: tempRoot });
+  return { tempRoot, httpModulePath: path.join(tempRoot, '_lib', 'http.js') };
 }
 
 function req(url, origin, extra = {}) {

--- a/apps/webmail/scripts/typescript-compile.mjs
+++ b/apps/webmail/scripts/typescript-compile.mjs
@@ -1,0 +1,90 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const require = createRequire(import.meta.url);
+const typescriptRoot = path.dirname(require.resolve('typescript/package.json'));
+const tscEntry = path.join(typescriptRoot, 'bin', 'tsc');
+
+function emittedPath(outDir, sourceRoot, sourcePath) {
+  const relative = path.relative(sourceRoot, sourcePath).replace(/\.(?:cts|mts|tsx?|jsx?)$/i, '.js');
+  return path.join(outDir, relative);
+}
+
+function normalizeRelativeSpecifier(specifier) {
+  if (/\.(?:[cm]?js|json|node)$/i.test(specifier)) return specifier;
+  if (/\.(?:cts|mts|tsx?|jsx?)$/i.test(specifier)) return specifier.replace(/\.(?:cts|mts|tsx?|jsx?)$/i, '.js');
+  return `${specifier}.js`;
+}
+
+function patchRelativeImports(source) {
+  const patch = (_match, before, specifier, after) => `${before}${normalizeRelativeSpecifier(specifier)}${after}`;
+  return source
+    .replace(/((?:from|import)\s*["'])(\.{1,2}\/[^"']+)(["'])/g, patch)
+    .replace(/(import\s*\(\s*["'])(\.{1,2}\/[^"']+)(["'])/g, patch);
+}
+
+async function walkJavaScript(root) {
+  const files = [];
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) files.push(...await walkJavaScript(full));
+    else if (entry.isFile() && entry.name.endsWith('.js')) files.push(full);
+  }
+  return files;
+}
+
+export async function compileTypeScriptFiles({ sourceRoot, rootFiles, outDir }) {
+  const resolvedSourceRoot = path.resolve(sourceRoot);
+  const resolvedOutDir = path.resolve(outDir);
+  const resolvedRootFiles = rootFiles.map((file) => path.resolve(file));
+  await mkdir(resolvedOutDir, { recursive: true });
+
+  try {
+    await execFileAsync(process.execPath, [
+      tscEntry,
+      '--pretty', 'false',
+      '--ignoreConfig',
+      '--target', 'ES2022',
+      '--module', 'ESNext',
+      '--moduleResolution', 'Bundler',
+      '--noCheck',
+      '--skipLibCheck',
+      '--rootDir', resolvedSourceRoot,
+      '--outDir', resolvedOutDir,
+      ...resolvedRootFiles,
+    ], {
+      windowsHide: true,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+  } catch (error) {
+    const details = [error?.stdout, error?.stderr].filter(Boolean).join('\n').trim();
+    throw new Error(details || error?.message || 'TypeScript compilation failed', { cause: error });
+  }
+
+  await writeFile(path.join(resolvedOutDir, 'package.json'), '{"type":"module"}\n', 'utf8');
+  for (const outputPath of await walkJavaScript(resolvedOutDir)) {
+    const source = await readFile(outputPath, 'utf8');
+    const patched = patchRelativeImports(source);
+    if (patched !== source) await writeFile(outputPath, patched, 'utf8');
+  }
+}
+
+export async function importStandaloneTypeScriptModule(sourceUrl) {
+  const sourcePath = fileURLToPath(sourceUrl);
+  const sourceRoot = path.dirname(sourcePath);
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'loven7-typescript-module-'));
+  const outDir = path.join(tempRoot, 'compiled');
+
+  try {
+    await compileTypeScriptFiles({ sourceRoot, rootFiles: [sourcePath], outDir });
+    return await import(pathToFileURL(emittedPath(outDir, sourceRoot, sourcePath)).href);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Summary
- upgrade Admin and Webmail together to TypeScript 7.0.2
- replace removed `transpileModule` usage in five Webmail validation scripts
- add one shared compiler helper that invokes the installed TypeScript 7 `tsc` CLI
- normalize emitted ESM import extensions for temporary Cloudflare Functions test modules

## Why one PR
The separate Dependabot PRs #6 and #12 migrate only one application at a time. TypeScript 7 also removes the old compiler API from the package root, so the Webmail Functions validation harness must move in the same change.

## Validation
- confirmed both local compilers report `Version 7.0.2`
- `npm run check:release`
- public release and Cloudflare preflight passed
- installer: 81 tests passed
- Admin: 86 tests passed
- Webmail: 31 tests passed
- all Webmail Functions checks passed
- Admin/Webmail production builds passed
- Admin/Webmail browser smoke tests returned `ok: true`
- `git diff --check`

Supersedes #6 and #12.