### PR TITLE
chore(deps): upgrade both apps to postal-mime 3

### DIFF
--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@vitejs/plugin-react": "^6.0.5",
         "lucide-react": "^0.546.0",
-        "postal-mime": "^2.7.6",
+        "postal-mime": "^3.0.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "vite": "^8.2.1",
@@ -5071,9 +5071,9 @@
       }
     },
     "node_modules/postal-mime": {
-      "version": "2.7.6",
-      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.6.tgz",
-      "integrity": "sha512-UUlyE2KlxmvwMGq060onF/VWU3zD6dVW31FwokQ5v26jWd35fbs2MoTFzh+jXnPwAyV2MULMKXcBInGOl5TO6Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-3.0.0.tgz",
+      "integrity": "sha512-Z4a9ar2Bv3YpK3IXag+Yda30k7bMZfpRuUGyqtHnZ2pjHG8Bl62EhZIk4n1dzv00gfzP9g+94e9kd8+XmjVWLA==",
       "license": "MIT-0"
     },
     "node_modules/postcss": {

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@vitejs/plugin-react": "^6.0.5",
     "lucide-react": "^0.546.0",
-    "postal-mime": "^2.7.6",
+    "postal-mime": "^3.0.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "vite": "^8.2.1",

--- a/apps/admin/src/lib/mailParser.ts
+++ b/apps/admin/src/lib/mailParser.ts
@@ -465,8 +465,8 @@ export function parseRawMailListItem(item: RawMailRecord): ParsedMail {
 async function parseWithPostalMime(raw: string): Promise<any | null> {
   try {
     const mod = await import('postal-mime');
-    const PostalMime = mod.default;
-    return await PostalMime.parse(raw || '');
+    const parser = new mod.default({ attachmentEncoding: 'arraybuffer' });
+    return await parser.parse(raw || '');
   } catch (error) {
     console.warn('postal-mime unavailable, using simple parser', error);
     return null;

--- a/apps/admin/tests/frontend-release.test.ts
+++ b/apps/admin/tests/frontend-release.test.ts
@@ -11,7 +11,7 @@ import { buildCacheScope, scopedStorageKey } from '../src/lib/cacheScope.ts';
 import { buildAddressLoginUrl } from '../src/lib/clipboard.ts';
 import { UserApiError, addressMailEndpoint, changeAddressPassword, createUserShare, fetchUserProfile, isAuthenticationFailure, loginAccountUser, registerAccountUser } from '../src/lib/userAuth.ts';
 import { readTrustedMailFrameMessage } from '../src/lib/mailFrameMessages.ts';
-import { hasExternalMailImages, parseRawMailListItem } from '../src/lib/mailParser.ts';
+import { hasExternalMailImages, parseRawMail, parseRawMailListItem } from '../src/lib/mailParser.ts';
 import { adminMailStateEndpoint } from '../src/lib/mailStateEndpoint.ts';
 import { proxyMailImageSrcset, proxyMailImageUrl } from '../src/lib/mailImageProxy.ts';
 import { sanitizeMailHtmlWithoutDom } from '../src/lib/mailSanitizerFallback.ts';
@@ -166,6 +166,47 @@ test('sender display names drop MIME quoting artifacts', () => {
   assert.equal(unbalanced.senderName, 'Unbalanced');
   const backslash = parseRawMailListItem({ id: 5, raw: 'From: Back\\slash <c@x.test>\r\nSubject: Hi\r\n\r\nBody' } as never);
   assert.equal(backslash.senderName, 'Back\\slash');
+});
+
+test('admin parses a real MIME message through postal-mime', async () => {
+  const parsed = await parseRawMail({
+    id: 101,
+    address: 'inbox@example.test',
+    raw: [
+      'From: =?UTF-8?B?5rWL6K+V?= <sender@example.test>',
+      'To: first@example.test',
+      'To: second@example.test',
+      'Subject: =?UTF-8?B?5rWL6K+V5L2g5aW9?=',
+      'Subject: This duplicate must not win',
+      'MIME-Version: 1.0',
+      'Content-Type: multipart/mixed; boundary="mail-boundary"',
+      '',
+      '--mail-boundary',
+      'Content-Type: text/plain; charset=utf-8',
+      'Content-Transfer-Encoding: 8bit',
+      '',
+      '正文内容 472913',
+      '--mail-boundary',
+      'Content-Type: text/plain; name="note.txt"',
+      'Content-Disposition: attachment; filename="note.txt"',
+      'Content-Transfer-Encoding: base64',
+      '',
+      'SGVsbG8=',
+      '--mail-boundary--',
+      '',
+    ].join('\r\n'),
+  } as never);
+
+  assert.equal(parsed.senderName, '测试');
+  assert.equal(parsed.senderAddress, 'sender@example.test');
+  assert.equal(parsed.subject, '测试你好');
+  assert.equal(parsed.to, 'first@example.test, second@example.test');
+  assert.match(parsed.text, /正文内容 472913/);
+  assert.match(parsed.message, /正文内容/);
+  assert.equal(parsed.attachments.length, 1);
+  assert.equal(parsed.attachments[0].filename, 'note.txt');
+  assert.equal(parsed.attachments[0].mimeType, 'text/plain');
+  assert.equal(parsed.attachments[0].bytes, 5);
 });
 
 test('admin mail sanitizer fails closed when DOMParser is unavailable', () => {

--- a/apps/webmail/package-lock.json
+++ b/apps/webmail/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.1",
       "dependencies": {
         "@vitejs/plugin-react": "^6.0.5",
-        "postal-mime": "^2.7.6",
+        "postal-mime": "^3.0.0",
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "typescript": "~7.0.2",
@@ -957,9 +957,9 @@
       }
     },
     "node_modules/postal-mime": {
-      "version": "2.7.6",
-      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.6.tgz",
-      "integrity": "sha512-UUlyE2KlxmvwMGq060onF/VWU3zD6dVW31FwokQ5v26jWd35fbs2MoTFzh+jXnPwAyV2MULMKXcBInGOl5TO6Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-3.0.0.tgz",
+      "integrity": "sha512-Z4a9ar2Bv3YpK3IXag+Yda30k7bMZfpRuUGyqtHnZ2pjHG8Bl62EhZIk4n1dzv00gfzP9g+94e9kd8+XmjVWLA==",
       "license": "MIT-0"
     },
     "node_modules/postcss": {

--- a/apps/webmail/package.json
+++ b/apps/webmail/package.json
@@ -23,7 +23,7 @@
     "typescript": "~7.0.2",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "postal-mime": "^2.7.6"
+    "postal-mime": "^3.0.0"
   },
   "devDependencies": {
     "@types/react": "19.2.18",


### PR DESCRIPTION
## Summary
- upgrade Admin and Webmail from postal-mime 2.7.6 to 3.0.0
- use the instance parser API consistently in Admin
- add a real MIME regression covering first-wins headers, recipient order, UTF-8 headers, and attachments

## Verification
- npm run check:release
- Admin: 87 tests
- Webmail: 31 tests
- installer: 81 tests
- Functions checks, production builds, PWA generation, browser smoke, and clean npm installs passed

Closes #25
Closes #27