### PR TITLE
style(webmail): soften typography weights

### DIFF
--- a/apps/webmail/scripts/smoke-local.mjs
+++ b/apps/webmail/scripts/smoke-local.mjs
@@ -448,6 +448,10 @@ async function run() {
     hasLoadingText: document.body.innerText.includes('正在优化') || document.body.innerText.includes('Loading images'),
     signedInBrandLogo: !!document.querySelector('.mail-list-header .brand-logo'),
     uiFontFamily: getComputedStyle(document.querySelector('.mail-title-heading')).fontFamily,
+    titleFontWeight: getComputedStyle(document.querySelector('.mail-title-heading')).fontWeight,
+    senderFontWeight: getComputedStyle(document.querySelector('.mail-sender')).fontWeight,
+    subjectFontWeight: getComputedStyle(document.querySelector('.mail-subject')).fontWeight,
+    detailSubjectFontWeight: getComputedStyle(document.querySelector('.mail-detail-subject')).fontWeight,
     codeFontFamily: getComputedStyle(document.querySelector('.verification-code-button')).fontFamily,
     addressText: address?.textContent || '',
     addressFits: !!address && address.scrollWidth <= address.clientWidth + 1,
@@ -466,6 +470,7 @@ async function run() {
   assert(!inboxMetrics.hasLoadingText, '切换/加载邮件时不应显示冗余图片优化文案');
   assert(!inboxMetrics.signedInBrandLogo, `登录后的邮箱左栏不应继续堆叠品牌 Logo: ${JSON.stringify(inboxMetrics)}`);
   assert(!inboxMetrics.uiFontFamily.includes('Maple Mono') && inboxMetrics.uiFontFamily.includes('Segoe UI'), `Webmail UI 应使用与 Admin 一致的系统无衬线字体栈: ${JSON.stringify(inboxMetrics)}`);
+  assert(inboxMetrics.titleFontWeight === '540' && inboxMetrics.senderFontWeight === '450' && inboxMetrics.subjectFontWeight === '500' && inboxMetrics.detailSubjectFontWeight === '500', `Webmail 标题与邮件列表应保持轻量字重层级: ${JSON.stringify(inboxMetrics)}`);
   assert(/SF Mono|SFMono-Regular|Menlo|Consolas|monospace/.test(inboxMetrics.codeFontFamily), `验证码应继续使用易辨认的等宽字体: ${JSON.stringify(inboxMetrics)}`);
   assert(inboxMetrics.addressText === 'rj6ckfgq8lb@c.loven.qzz.io' && inboxMetrics.addressFits && inboxMetrics.addressWhiteSpace === 'nowrap' && inboxMetrics.addressLines === 1, `常见长度邮箱必须完整单行显示: ${JSON.stringify(inboxMetrics)}`);
   assert(inboxMetrics.addressContentCenterDelta <= 1 && inboxMetrics.controlCenterDelta <= 1, `邮箱地址内容必须与右侧刷新控件垂直居中: ${JSON.stringify(inboxMetrics)}`);

--- a/apps/webmail/src/mailWorkspace.css
+++ b/apps/webmail/src/mailWorkspace.css
@@ -126,7 +126,7 @@
   border-radius: var(--lm-radius-control-sm);
   color: var(--lm-text);
   font-size: 13px;
-  font-weight: 550 !important;
+  font-weight: 450 !important;
 }
 
 .mail-list-header .address-copy-text {
@@ -191,7 +191,7 @@
   color: var(--lm-text-strong);
   font-family: var(--mail-ui-font, var(--font-ui)) !important;
   font-size: 22px;
-  font-weight: 600 !important;
+  font-weight: 540 !important;
   line-height: 1.2;
 }
 
@@ -369,7 +369,7 @@
   overflow: hidden;
   color: var(--lm-text-soft);
   font-size: 13.5px;
-  font-weight: 500 !important;
+  font-weight: 450 !important;
   line-height: 1.35;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -424,7 +424,7 @@
   color: var(--lm-text-strong);
   font-family: var(--mail-ui-font, var(--font-ui)) !important;
   font-size: 14px;
-  font-weight: 600 !important;
+  font-weight: 500 !important;
   line-height: 1.38;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -483,7 +483,7 @@
   font-family: var(--font-code) !important;
   font-size: 11.5px;
   font-variant-numeric: tabular-nums;
-  font-weight: 600 !important;
+  font-weight: 500 !important;
   letter-spacing: 0;
   line-height: 1;
   cursor: pointer;
@@ -686,7 +686,7 @@
   color: var(--lm-text-strong);
   font-family: var(--font-display) !important;
   font-size: clamp(21px, 2vw, 26px);
-  font-weight: 550 !important;
+  font-weight: 500 !important;
   letter-spacing: 0;
   line-height: 1.32;
   overflow-wrap: anywhere;
@@ -719,7 +719,7 @@
   overflow: hidden;
   color: var(--lm-text);
   font-size: 14px;
-  font-weight: 550 !important;
+  font-weight: 500 !important;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/apps/webmail/src/styles.css
+++ b/apps/webmail/src/styles.css
@@ -2117,10 +2117,10 @@ input {
   --font-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
   --font-brand: "Loven7 Brand Script", "Segoe Script", "Snell Roundhand", "Lucida Handwriting", "Brush Script MT", "Baskerville Italic", "Georgia", cursive;
   --fw-body: 400;
-  --fw-subtle: 450;
-  --fw-medium: 500;
-  --fw-strong: 600;
-  --fw-emphasis: 680;
+  --fw-subtle: 400;
+  --fw-medium: 450;
+  --fw-strong: 520;
+  --fw-emphasis: 600;
   --lm-font-ui: var(--font-ui);
 }
 :root[data-font-mode="en"] {

--- a/apps/webmail/tests/frontend-release.test.ts
+++ b/apps/webmail/tests/frontend-release.test.ts
@@ -279,10 +279,10 @@ test("webmail typography matches Admin while verification codes stay monospaced"
   assert.match(theme, /--font-code:\s*ui-monospace,[^;]*"SF Mono"[^;]*Consolas[^;]*monospace/);
   assert.match(theme, /:root\[data-font-mode="en"\][\s\S]*--mail-ui-font:\s*var\(--font-ui\)/);
   assert.match(workspace, /\.mail-workspace,[\s\S]*font-family:\s*var\(--mail-ui-font, var\(--font-ui\)\)\s*!important/);
-  assert.match(workspace, /\.mail-title-heading\s*\{[\s\S]*font-family:\s*var\(--mail-ui-font, var\(--font-ui\)\)\s*!important[\s\S]*font-weight:\s*600\s*!important/);
-  assert.match(workspace, /\.mail-subject\s*\{[\s\S]*font-family:\s*var\(--mail-ui-font, var\(--font-ui\)\)\s*!important[\s\S]*font-weight:\s*600\s*!important/);
+  assert.match(workspace, /\.mail-title-heading\s*\{[\s\S]*font-family:\s*var\(--mail-ui-font, var\(--font-ui\)\)\s*!important[\s\S]*font-weight:\s*540\s*!important/);
+  assert.match(workspace, /\.mail-subject\s*\{[\s\S]*font-family:\s*var\(--mail-ui-font, var\(--font-ui\)\)\s*!important[\s\S]*font-weight:\s*500\s*!important/);
   assert.match(workspace, /\.verification-code-button\s*\{[\s\S]*font-family:\s*var\(--font-code\)\s*!important/);
-  assert.match(workspace, /\.mail-detail-subject,[\s\S]*font-weight:\s*550\s*!important/);
+  assert.match(workspace, /\.mail-detail-subject,[\s\S]*font-weight:\s*500\s*!important/);
 });
 
 test("signed-in mail list uses calm hierarchy, visible row boundaries, and inline verification actions", () => {


### PR DESCRIPTION
## Summary
- reduce Webmail heading, sender, subject, control, and verification-code weights
- preserve a clear unread/read hierarchy without heavy bold text
- add browser assertions for the actual computed font weights

## Verification
- Webmail tests: 31 passed
- Webmail build passed
- Webmail browser smoke passed with title 540, sender 450, subject 500, and detail subject 500